### PR TITLE
fix a crash of NumberOfExecutions analysis

### DIFF
--- a/mlir/lib/Analysis/NumberOfExecutions.cpp
+++ b/mlir/lib/Analysis/NumberOfExecutions.cpp
@@ -115,7 +115,8 @@ static void computeRegionBlockNumberOfExecutions(
 /// block within a region is executed for all associated regions.
 NumberOfExecutions::NumberOfExecutions(Operation *op) : operation(op) {
   operation->walk<WalkOrder::PreOrder>([&](Region *region) {
-    computeRegionBlockNumberOfExecutions(*region, blockNumbersOfExecution);
+    if (!region->empty())
+      computeRegionBlockNumberOfExecutions(*region, blockNumbersOfExecution);
   });
 }
 


### PR DESCRIPTION
This analysis was deleted through 69bc334 commit.
It was originally added for the async reference counting, but it turned out to be not useful.
